### PR TITLE
add Item mapping tab for Actor compendiums and improve RollTable export

### DIFF
--- a/scripts/app/compendium-exporter-app.mjs
+++ b/scripts/app/compendium-exporter-app.mjs
@@ -98,7 +98,7 @@ export class CompendiumExporterApp extends api.HandlebarsApplicationMixin(api.Ap
       context.fields = this.#object.schema.fields;
       context.rootId = this.id;
 
-      if (context.adventureMapping) {
+      if (context.actorMapping || context.adventureMapping) {
         context.tabs = this._prepareTabs('mapping');
       }
     }

--- a/scripts/exporters/rolltable-exporter.mjs
+++ b/scripts/exporters/rolltable-exporter.mjs
@@ -10,13 +10,19 @@ export class RollTableExporter extends AbstractExporter {
     const documentData = { name, description };
 
     if (this._notEmpty(document.results)) {
-      documentData.results = {};
+        documentData.results = {};
+        for (const result of document.results) {
+            const { range, name, description: resultDesc } = result; 
+            const rangeKey = `${range[0]}-${range[1]}`;
 
-      for (const { range, text } of document.results) {
-        documentData.results[`${range[0]}-${range[1]}`] = text;
-      }
+            const resultData = { name };
+
+            if (resultDesc !== undefined && resultDesc !== '') {
+                resultData.description = resultDesc;
+            }
+
+            documentData.results[rangeKey] = resultData;
+        }
     }
-
     return documentData;
-  }
 }

--- a/templates/_export.html.hbs
+++ b/templates/_export.html.hbs
@@ -17,9 +17,15 @@
       <legend>{{localize "BTFG.CompendiumExporter.CustomMapping"}}</legend>
       <p class="notes">{{localize "BTFG.CompendiumExporter.CustomMappingHint"}}</p>
 
-      {{#if actorMapping}}
-        {{> (template "_default-mapping.html.hbs") type="actor" mapping=object.customMapping.actor}}
-      {{/if}}
+  {{#if actorMapping}}
+      {{> "templates/generic/tab-navigation.hbs" tabs=tabs}}
+      <div class="tab{{#if tabs.actor.active}} active{{/if}}" data-group="mapping" data-tab="actor">
+          {{> (template "_default-mapping.html.hbs") type="actor" mapping=object.customMapping.actor}}
+      </div>
+      <div class="tab{{#if tabs.item.active}} active{{/if}}" data-group="mapping" data-tab="item">
+          {{> (template "_default-mapping.html.hbs") type="item" mapping=object.customMapping.item}}
+      </div>
+  {{/if}}
 
       {{#if adventureMapping}}
         {{> "templates/generic/tab-navigation.hbs" tabs=tabs}}


### PR DESCRIPTION
## Description
This PR introduces two major enhancements to BTFG:

1. **Item mapping tab for Actor compendiums** – Allows users to define custom mappings (e.g., `description`) for items owned by actors.
2. **Fix RollTable export** – Adapts to Foundry V13 data structure: exports `name` and `description` for each result, replacing the deprecated `text` field.

## Changes

### Actor Item Mapping
- Modified `compendium-exporter-app.js` to generate tabs for Actor packs (previously only for Adventure).
- Updated `_export.html.hbs` to render "Actor Mapping" and "Item Mapping" tabs using `tab-navigation.hbs`.
- No changes to `actor-exporter.js` (already supports `itemMapping`).

### RollTable Export Fix
- **File changed**: `rolltable-exporter.js`
- **Before**: Exported results as `{ "1-4": "text_string" }` using the deprecated `text` field.
- **After**: Exports as `{ "1-4": { "name": "result_name", "description": "result_description" } }` (if description exists).
- **Compatibility**: The new format aligns with Foundry V13 `TableResult` schema (`name` for display text, `description` for optional details).